### PR TITLE
Fixed a few more valgrind issues

### DIFF
--- a/src/CPUSolver.cpp
+++ b/src/CPUSolver.cpp
@@ -135,6 +135,9 @@ void CPUSolver::initializeFluxArrays() {
     size = _num_FSRs * _num_groups;
     _scalar_flux = new FP_PRECISION[size];
     _old_scalar_flux = new FP_PRECISION[size];
+    
+    /* Set the old scalar flux to zero */
+    memset(_old_scalar_flux, 0.0, sizeof(FP_PRECISION) * size);
   }
   catch(std::exception &e) {
     log_printf(ERROR, "Could not allocate memory for the fluxes");

--- a/src/CPUSolver.cpp
+++ b/src/CPUSolver.cpp
@@ -135,9 +135,6 @@ void CPUSolver::initializeFluxArrays() {
     size = _num_FSRs * _num_groups;
     _scalar_flux = new FP_PRECISION[size];
     _old_scalar_flux = new FP_PRECISION[size];
-    
-    /* Set the old scalar flux to zero */
-    memset(_old_scalar_flux, 0.0, sizeof(FP_PRECISION) * size);
   }
   catch(std::exception &e) {
     log_printf(ERROR, "Could not allocate memory for the fluxes");
@@ -193,15 +190,18 @@ void CPUSolver::zeroTrackFluxes() {
 
 
 /**
- * @brief Set the scalar flux for each FSR and energy group to some value.
+ * @brief Set both the current and old scalar flux for each FSR and
+ *        energy group to some value.
  * @param value the value to assign to each FSR scalar flux
  */
 void CPUSolver::flattenFSRFluxes(FP_PRECISION value) {
 
   #pragma omp parallel for schedule(guided)
   for (int r=0; r < _num_FSRs; r++) {
-    for (int e=0; e < _num_groups; e++)
+    for (int e=0; e < _num_groups; e++) {
       _scalar_flux(r,e) = value;
+      _old_scalar_flux(r,e) = value;
+    }
   }
 }
 

--- a/src/TrackGenerator.cpp
+++ b/src/TrackGenerator.cpp
@@ -1344,7 +1344,7 @@ bool TrackGenerator::readTracksFromFile() {
   for (int i=0; i < _num_azim; i++)
     _azim_weights[i] = azim_weights[i];
 
-  free(azim_weights);
+  delete [] azim_weights;
 
   Track* curr_track;
   double x0, y0, x1, y1;

--- a/src/accel/cuda/GPUSolver.cu
+++ b/src/accel/cuda/GPUSolver.cu
@@ -1173,11 +1173,13 @@ void GPUSolver::zeroTrackFluxes() {
 
 
 /**
- * @brief Set the FSR scalar flux for each energy group to some value.
+ * @brief Set both the current and old scalar flux for each FSR and
+ *        energy group to some value.
  * @param value the value to assign to each FSR scalar flux
  */
 void GPUSolver::flattenFSRFluxes(FP_PRECISION value) {
   thrust::fill(_scalar_flux.begin(), _scalar_flux.end(), value);
+  thrust::fill(_old_scalar_flux.begin(), _old_scalar_flux.end(), value);
 }
 
 


### PR DESCRIPTION
This sets the old flux to zero so that when the residual is calculated, it does not access uninitialized memory.  I also switched one more free() to delete [].
